### PR TITLE
Joystick D-Pad

### DIFF
--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -236,10 +236,12 @@ void XInputController::setDpad(XInputControl pad, boolean state) {
 	setButton(pad, state);
 }
 
-void XInputController::setDpad(boolean up, boolean down, boolean left, boolean right) {
+void XInputController::setDpad(boolean up, boolean down, boolean left, boolean right, boolean useSOCD) {
 	// Simultaneous Opposite Cardinal Directions (SOCD) Cleaner
-	if (up && down) { down = false; }  // Up + Down = Up
-	if (left && right) { left = false; right = false; }  // Left + Right = Neutral
+	if (useSOCD) {
+		if (up && down) { down = false; }  // Up + Down = Up
+		if (left && right) { left = false; right = false; }  // Left + Right = Neutral
+	}
 
 	const boolean autoSendTemp = autoSendOption;  // Save autosend state
 	autoSendOption = false;  // Disable temporarily

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -259,7 +259,7 @@ void XInputController::setTrigger(XInputControl trigger, int32_t val) {
 	const XInputMap_Trigger * triggerData = getTriggerFromEnum(trigger);
 	if (triggerData == nullptr) return;  // Not a trigger
 
-	val = rescaleInput(val, *getRangeFromEnum(trigger), triggerData->range);
+	val = rescaleInput(val, *getRangeFromEnum(trigger), XInputMap_Trigger::range);
 	if (getTrigger(trigger) == val) return;  // Trigger hasn't changed
 
 	tx[triggerData->index] = val;
@@ -271,8 +271,8 @@ void XInputController::setJoystick(XInputControl joy, int32_t x, int32_t y) {
 	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
 	if (joyData == nullptr) return;  // Not a joystick
 
-	x = rescaleInput(x, *getRangeFromEnum(joy), joyData->range);
-	y = rescaleInput(y, *getRangeFromEnum(joy), joyData->range);
+	x = rescaleInput(x, *getRangeFromEnum(joy), XInputMap_Joystick::range);
+	y = rescaleInput(y, *getRangeFromEnum(joy), XInputMap_Joystick::range);
 
 	setJoystickDirect(joy, x, y);
 }

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -274,6 +274,13 @@ void XInputController::setJoystick(XInputControl joy, int32_t x, int32_t y) {
 	x = rescaleInput(x, *getRangeFromEnum(joy), joyData->range);
 	y = rescaleInput(y, *getRangeFromEnum(joy), joyData->range);
 
+	setJoystickDirect(joy, x, y);
+}
+
+void XInputController::setJoystickDirect(XInputControl joy, int16_t x, int16_t y) {
+	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
+	if (joyData == nullptr) return;  // Not a joystick
+
 	if (getJoystickX(joy) == x && getJoystickY(joy) == y) return;  // Joy hasn't changed
 
 	tx[joyData->x_low]  = lowByte(x);

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -277,6 +277,27 @@ void XInputController::setJoystick(XInputControl joy, int32_t x, int32_t y) {
 	setJoystickDirect(joy, x, y);
 }
 
+void XInputController::setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right) {
+	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
+	if (joyData == nullptr) return;  // Not a joystick
+
+	const Range & range = XInputMap_Joystick::range;
+
+	int16_t x = 0;
+	int16_t y = 0;
+
+	// Simultaneous Opposite Cardinal Directions (SOCD) Cleaner
+	//  (Mutually exclusive. Avoids the '-1' result from adding the int16 extremes)
+	if (left != right) {
+		x = (right * range.max) - (left * range.min);
+	}
+	if (up != down) {
+		y = (up * range.max) - (down * range.min);
+	}
+
+	setJoystickDirect(joy, x, y);
+}
+
 void XInputController::setJoystickDirect(XInputControl joy, int16_t x, int16_t y) {
 	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
 	if (joyData == nullptr) return;  // Not a joystick

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -277,7 +277,7 @@ void XInputController::setJoystick(XInputControl joy, int32_t x, int32_t y) {
 	setJoystickDirect(joy, x, y);
 }
 
-void XInputController::setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right) {
+void XInputController::setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD) {
 	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
 	if (joyData == nullptr) return;  // Not a joystick
 
@@ -287,7 +287,14 @@ void XInputController::setJoystick(XInputControl joy, boolean up, boolean down, 
 	int16_t y = 0;
 
 	// Simultaneous Opposite Cardinal Directions (SOCD) Cleaner
-	//  (Mutually exclusive. Avoids the '-1' result from adding the int16 extremes)
+	if (useSOCD) {
+		if (up && down) { down = false; }  // Up + Down = Up
+		if (left && right) { left = false; right = false; }  // Left + Right = Neutral
+	}
+	
+	// Analog axis means directions are mutually exclusive. Only change the
+	// output from '0' if the per-axis inputs are different, in order to
+	// avoid the '-1' result from adding the int16 extremes
 	if (left != right) {
 		x = (right * range.max) - (left * range.min);
 	}

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -91,7 +91,7 @@ public:
 	void setTrigger(XInputControl trigger, int32_t val);
 
 	void setJoystick(XInputControl joy, int32_t x, int32_t y);
-	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right);
+	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD = true);
 
 	void releaseAll();
 

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -140,6 +140,8 @@ private:
 	uint8_t tx[20];  // USB transmit data
 	boolean newData;  // Flag for tx data changed
 	boolean autoSendOption;  // Flag for automatically sending data
+	
+	void setJoystickDirect(XInputControl joy, int16_t x, int16_t y);
 
 	void inline autosend() {
 		if (autoSendOption) { send(); }

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -91,6 +91,7 @@ public:
 	void setTrigger(XInputControl trigger, int32_t val);
 
 	void setJoystick(XInputControl joy, int32_t x, int32_t y);
+	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right);
 
 	void releaseAll();
 

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -86,7 +86,7 @@ public:
 	void setButton(uint8_t button, boolean state);
 
 	void setDpad(XInputControl pad, boolean state);
-	void setDpad(boolean up, boolean down, boolean left, boolean right);
+	void setDpad(boolean up, boolean down, boolean left, boolean right, boolean useSOCD = true);
 
 	void setTrigger(XInputControl trigger, int32_t val);
 


### PR DESCRIPTION
Adds a function to set the analog joystick outputs as if they were directional pads (using four digital inputs). Useful if you're using arcade joysticks that have four microswitches instead of potentiometers.

The Simultaneous Opposite Cardinal Directions (SOCD) cleaner for this defaults to neutral for both combinations because that seems like more idiomatic behavior for a joystick. If the user wants up + down to equal 'up' they can catch that before passing the result to the function. E.g.:

```cpp
if(up && down) { down = false; }
XInput.setJoystick(JOY_LEFT, up, down, left, right);
```

This pull request also makes the SOCD cleaner for the directional pad function optional. The user can pass an additional 'false' argument to disable it.