### PR TITLE
Joystick Single Axis Functions

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -33,6 +33,8 @@ setButton	KEYWORD2
 setDpad	KEYWORD2
 setTrigger	KEYWORD2
 setJoystick	KEYWORD2
+setJoystickX	KEYWORD2
+setJoystickY	KEYWORD2
 
 releaseAll	KEYWORD2
 

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -296,10 +296,12 @@ void XInputController::setJoystick(XInputControl joy, boolean up, boolean down, 
 	// output from '0' if the per-axis inputs are different, in order to
 	// avoid the '-1' result from adding the int16 extremes
 	if (left != right) {
-		x = (right * range.max) - (left * range.min);
+		if (left == true) { x = range.min; }
+		else if (right == true) { x = range.max; }
 	}
 	if (up != down) {
-		y = (up * range.max) - (down * range.min);
+		if (up == true) { y = range.max; }
+		else if (down == true) { y = range.min; }
 	}
 
 	setJoystickDirect(joy, x, y);

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -277,6 +277,36 @@ void XInputController::setJoystick(XInputControl joy, int32_t x, int32_t y) {
 	setJoystickDirect(joy, x, y);
 }
 
+void XInputController::setJoystickX(XInputControl joy, int32_t x) {
+	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
+	if (joyData == nullptr) return;  // Not a joystick
+
+	x = rescaleInput(x, *getRangeFromEnum(joy), XInputMap_Joystick::range);
+
+	if (getJoystickX(joy) == x) return;  // Axis hasn't changed
+
+	tx[joyData->x_low] = lowByte(x);
+	tx[joyData->x_high] = highByte(x);
+
+	newData = true;
+	autosend();
+}
+
+void XInputController::setJoystickY(XInputControl joy, int32_t y) {
+	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
+	if (joyData == nullptr) return;  // Not a joystick
+
+	y = rescaleInput(y, *getRangeFromEnum(joy), XInputMap_Joystick::range);
+
+	if (getJoystickY(joy) == y) return;  // Axis hasn't changed
+
+	tx[joyData->y_low] = lowByte(y);
+	tx[joyData->y_high] = highByte(y);
+
+	newData = true;
+	autosend();
+}
+
 void XInputController::setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD) {
 	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
 	if (joyData == nullptr) return;  // Not a joystick

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -92,6 +92,8 @@ public:
 
 	void setJoystick(XInputControl joy, int32_t x, int32_t y);
 	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD = true);
+	void setJoystickX(XInputControl joy, int32_t x);
+	void setJoystickY(XInputControl joy, int32_t y);
 
 	void releaseAll();
 


### PR DESCRIPTION
Adds two functions for manipulating the joystick axes separately: `setJoystickX` and `setJoystickY`. For those rare cases where you want to only set one axis, you don't need to determine the pre-scaled 'center' value for the other axis.

Note that both axes still share the same input range values (and I have no plans to change that). But I think these will be useful functions for those mapping non-joystick devices to the joystick outputs.

This pull request also changes the 4-button joystick function to use 'if' statements rather than multiplication in the back-end. It's more literally what I was trying to do, and it avoids requiring the compiler to optimize away the multiplication operation.