### PR TITLE
Add L3 and R3 to printDebug

### DIFF
--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -559,6 +559,15 @@ void XInputController::reset() {
 	autoSendOption = true;
 }
 
+static void fillBuffer(char* buff, const char fill) {
+	uint8_t i = 0;
+	while (true) {
+		if (buff[i] == 0) break;
+		buff[i] = fill;
+		i++;
+	}
+}
+
 void XInputController::printDebug(Print &output) const {
 	const char fillCharacter = '_';
 
@@ -584,14 +593,8 @@ void XInputController::printDebug(Print &output) const {
 	char leftBumper[3]  = "LB";
 	char rightBumper[3] = "RB";
 
-	if (!getButton(BUTTON_LB)) {
-		leftBumper[0] = fillCharacter;
-		leftBumper[1] = fillCharacter;
-	}
-	if (!getButton(BUTTON_RB)) {
-		rightBumper[0] = fillCharacter;
-		rightBumper[1] = fillCharacter;
-	}
+	if (!getButton(BUTTON_LB)) fillBuffer(leftBumper,  fillCharacter);
+	if (!getButton(BUTTON_RB)) fillBuffer(rightBumper, fillCharacter);
 
 	output.print("XInput Debug: ");
 	sprintf(buffer,

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -570,8 +570,26 @@ static void fillBuffer(char* buff, const char fill) {
 
 void XInputController::printDebug(Print &output) const {
 	const char fillCharacter = '_';
+	char buffer[34];
 
-	char buffer[88];
+	output.print("XInput Debug: ");
+
+	// Left Side Controls
+	char leftBumper[3] = "LB";
+	char leftJoyBtn[3] = "L3";
+
+	if (!getButton(BUTTON_LB)) fillBuffer(leftBumper, fillCharacter);
+	if (!getButton(BUTTON_L3)) fillBuffer(leftJoyBtn, fillCharacter);
+
+	sprintf(buffer,
+		"LT: %3u %s L:(%6d, %6d, %s)",
+
+		getTrigger(TRIGGER_LEFT),
+		leftBumper,
+		getJoystickX(JOY_LEFT), getJoystickY(JOY_LEFT),
+		leftJoyBtn
+	);
+	output.print(buffer);
 
 	// Face Buttons
 	const char dpadLPrint = getButton(DPAD_LEFT)  ? '<' : fillCharacter;
@@ -589,36 +607,25 @@ void XInputController::printDebug(Print &output) const {
 
 	const char logoPrint = getButton(BUTTON_LOGO) ? 'X' : fillCharacter;
 
-	// Bumpers
-	char leftBumper[3]  = "LB";
-	char rightBumper[3] = "RB";
-
-	if (!getButton(BUTTON_LB)) fillBuffer(leftBumper,  fillCharacter);
-	if (!getButton(BUTTON_RB)) fillBuffer(rightBumper, fillCharacter);
-
-	// Joystick Buttons
-	char leftJoyBtn[3]  = "L3";
-	char rightJoyBtn[3] = "R3";
-
-	if (!getButton(BUTTON_L3)) fillBuffer(leftJoyBtn,  fillCharacter);
-	if (!getButton(BUTTON_R3)) fillBuffer(rightJoyBtn, fillCharacter);
-
-	output.print("XInput Debug: ");
 	sprintf(buffer,
-		"LT: %3u %s L:(%6d, %6d, %s) %c%c%c%c | %c%c%c | %c%c%c%c R:(%6d, %6d, %s) %s RT: %3u",
-		
-		// Left side controls
-		getTrigger(TRIGGER_LEFT),
-		leftBumper,
-		getJoystickX(JOY_LEFT), getJoystickY(JOY_LEFT),
-		leftJoyBtn,
+		" %c%c%c%c | %c%c%c | %c%c%c%c ",
 
-		// Buttons
 		dpadLPrint, dpadUPrint, dpadDPrint, dpadRPrint,
 		backPrint, logoPrint, startPrint,
-		aButtonPrint, bButtonPrint, xButtonPrint, yButtonPrint,
+		aButtonPrint, bButtonPrint, xButtonPrint, yButtonPrint
+	);
+	output.print(buffer);
 
-		// Right side controls
+	// Right Side Controls
+	char rightBumper[3] = "RB";
+	char rightJoyBtn[3] = "R3";
+
+	if (!getButton(BUTTON_RB)) fillBuffer(rightBumper, fillCharacter);
+	if (!getButton(BUTTON_R3)) fillBuffer(rightJoyBtn, fillCharacter);
+
+	sprintf(buffer,
+		"R:(%6d, %6d, %s) %s RT: %3u",
+		
 		getJoystickX(JOY_RIGHT), getJoystickY(JOY_RIGHT),
 		rightJoyBtn,
 		rightBumper,

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -571,9 +571,9 @@ static void fillBuffer(char* buff, const char fill) {
 void XInputController::printDebug(Print &output) const {
 	const char fillCharacter = '_';
 
-	char buffer[80];
+	char buffer[88];
 
-	// Buttons
+	// Face Buttons
 	const char dpadLPrint = getButton(DPAD_LEFT)  ? '<' : fillCharacter;
 	const char dpadUPrint = getButton(DPAD_UP)    ? '^' : fillCharacter;
 	const char dpadDPrint = getButton(DPAD_DOWN)  ? 'v' : fillCharacter;
@@ -596,14 +596,22 @@ void XInputController::printDebug(Print &output) const {
 	if (!getButton(BUTTON_LB)) fillBuffer(leftBumper,  fillCharacter);
 	if (!getButton(BUTTON_RB)) fillBuffer(rightBumper, fillCharacter);
 
+	// Joystick Buttons
+	char leftJoyBtn[3]  = "L3";
+	char rightJoyBtn[3] = "R3";
+
+	if (!getButton(BUTTON_L3)) fillBuffer(leftJoyBtn,  fillCharacter);
+	if (!getButton(BUTTON_R3)) fillBuffer(rightJoyBtn, fillCharacter);
+
 	output.print("XInput Debug: ");
 	sprintf(buffer,
-		"LT: %3u %s L:(%6d, %6d) %c%c%c%c | %c%c%c | %c%c%c%c R:(%6d, %6d) %s RT: %3u",
+		"LT: %3u %s L:(%6d, %6d, %s) %c%c%c%c | %c%c%c | %c%c%c%c R:(%6d, %6d, %s) %s RT: %3u",
 		
 		// Left side controls
 		getTrigger(TRIGGER_LEFT),
 		leftBumper,
 		getJoystickX(JOY_LEFT), getJoystickY(JOY_LEFT),
+		leftJoyBtn,
 
 		// Buttons
 		dpadLPrint, dpadUPrint, dpadDPrint, dpadRPrint,
@@ -612,6 +620,7 @@ void XInputController::printDebug(Print &output) const {
 
 		// Right side controls
 		getJoystickX(JOY_RIGHT), getJoystickY(JOY_RIGHT),
+		rightJoyBtn,
 		rightBumper,
 		getTrigger(TRIGGER_RIGHT)
 	);


### PR DESCRIPTION
Although these worked in the XInput output mode, these two buttons were missing from the library's debug output.

This pull request also adds a small helper function for filling the bumper and joystick button strings with '_' when the buttons are unpressed. Lastly, this splits up the `sprintf` function call into three sections to reduce the size of the buffer required (88 bytes -> 34 bytes).

Other than the added buttons, this PR should not change the function's output.