### PR TITLE
Explicit Enums

### DIFF
--- a/src/XInput.h
+++ b/src/XInput.h
@@ -51,12 +51,12 @@ enum XInputControl : uint8_t {
 	JOY_RIGHT,
 };
 
-enum class XInputReceiveType {
+enum class XInputReceiveType : uint8_t {
 	Rumble = 0x00,
 	LEDs = 0x01,
 };
 
-enum class XInputLEDPattern {
+enum class XInputLEDPattern : uint8_t {
 	Off = 0x00,
 	Blinking = 0x01,
 	Flash1 = 0x02,

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -31,7 +31,7 @@
 
 enum XInputControl : uint8_t {
 	BUTTON_LOGO = 0,
-	BUTTON_A  = 1,
+	BUTTON_A = 1,
 	BUTTON_B = 2,
 	BUTTON_X = 3,
 	BUTTON_Y = 4,
@@ -41,12 +41,12 @@ enum XInputControl : uint8_t {
 	BUTTON_START = 8,
 	BUTTON_L3 = 9,
 	BUTTON_R3 = 10,
-	DPAD_UP,
-	DPAD_DOWN,
-	DPAD_LEFT,
-	DPAD_RIGHT,
-	TRIGGER_LEFT,
-	TRIGGER_RIGHT,
+	DPAD_UP = 11,
+	DPAD_DOWN = 12,
+	DPAD_LEFT = 13,
+	DPAD_RIGHT = 14,
+	TRIGGER_LEFT = 15,
+	TRIGGER_RIGHT = 16,
 	JOY_LEFT,
 	JOY_RIGHT,
 };


### PR DESCRIPTION
Making some implicit things explicit in order to indicate intent, and make sure these are consistent between different builds and configurations.

Originally I started this branch to create a `None` option for the `XInputReceiveType` to take care of a meta programming issue where you don't have a "NULL" option for a volatile flag taken from the arguments for a receive callback. But after much hemming and hawing I decided against it, as there is no known "safe" value that is guaranteed to be unused, and the user can always use a larger type like a signed int with -1.