### PR TITLE
Joystick Invert Option

### DIFF
--- a/examples/GamepadPins/GamepadPins.ino
+++ b/examples/GamepadPins/GamepadPins.ino
@@ -28,6 +28,8 @@
  *                and all of the main buttons.
  *
  *                * Joysticks should be your typical 10k dual potentiometers.
+ *                  To prevent random values caused by floating inputs,
+                    joysticks are disabled by default.
  *                * Triggers can be either analog (pots) or digital (buttons).
  *                  Set the 'TriggerButtons' variable to change between the two.
  *                * Buttons use the internal pull-ups and should be connected
@@ -187,12 +189,11 @@ void loop() {
 
 		// White lie here... most generic joysticks are typically
 		// inverted by default. If the "Invert" variable is false
-		// then we need to do this transformation.
-		if (InvertLeftYAxis == false) {
-			leftJoyY = ADC_Max - leftJoyY;
-		}
+		// then we'll take the opposite value with 'not' (!).
+		boolean invert = !InvertLeftYAxis;
 
-		XInput.setJoystick(JOY_LEFT, leftJoyX, leftJoyY);
+		XInput.setJoystickX(JOY_LEFT, leftJoyX);
+		XInput.setJoystickY(JOY_LEFT, leftJoyY, invert);
 	}
 
 	// Set right joystick
@@ -200,11 +201,10 @@ void loop() {
 		int rightJoyX = analogRead(Pin_RightJoyX);
 		int rightJoyY = analogRead(Pin_RightJoyY);
 
-		if (InvertRightYAxis == false) {
-			rightJoyY = ADC_Max - rightJoyY;
-		}
+		boolean invert = !InvertRightYAxis;
 
-		XInput.setJoystick(JOY_RIGHT, rightJoyX, rightJoyY);
+		XInput.setJoystickX(JOY_RIGHT, rightJoyX);
+		XInput.setJoystickY(JOY_RIGHT, rightJoyY, invert);
 	}
 
 	// Send control data to the computer

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -438,8 +438,8 @@ boolean XInputController::connected() {
 //Send an update packet to the PC
 int XInputController::send() {
 	if (!newData) return 0;  // TX data hasn't changed
-#ifdef USB_XINPUT
 	newData = false;
+#ifdef USB_XINPUT
 	return XInputUSB::send(tx, sizeof(tx));
 #else
 	printDebug();

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -514,7 +514,7 @@ XInputController::Range * XInputController::getRangeFromEnum(XInputControl ctrl)
 	}
 }
 
-int32_t XInputController::rescaleInput(int32_t val, Range in, Range out) {
+int32_t XInputController::rescaleInput(int32_t val, const Range& in, const Range& out) {
 	if (val <= in.min) return out.min;  // Out of range -
 	if (val >= in.max) return out.max;  // Out of range +
 	if (in.min == out.min && in.max == out.max) return val;  // Ranges identical

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -277,11 +277,12 @@ void XInputController::setJoystick(XInputControl joy, int32_t x, int32_t y) {
 	setJoystickDirect(joy, x, y);
 }
 
-void XInputController::setJoystickX(XInputControl joy, int32_t x) {
+void XInputController::setJoystickX(XInputControl joy, int32_t x, boolean invert) {
 	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
 	if (joyData == nullptr) return;  // Not a joystick
 
 	x = rescaleInput(x, *getRangeFromEnum(joy), XInputMap_Joystick::range);
+	if (invert) x = invertInput(x, XInputMap_Joystick::range);
 
 	if (getJoystickX(joy) == x) return;  // Axis hasn't changed
 
@@ -292,11 +293,12 @@ void XInputController::setJoystickX(XInputControl joy, int32_t x) {
 	autosend();
 }
 
-void XInputController::setJoystickY(XInputControl joy, int32_t y) {
+void XInputController::setJoystickY(XInputControl joy, int32_t y, boolean invert) {
 	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
 	if (joyData == nullptr) return;  // Not a joystick
 
 	y = rescaleInput(y, *getRangeFromEnum(joy), XInputMap_Joystick::range);
+	if (invert) y = invertInput(y, XInputMap_Joystick::range);
 
 	if (getJoystickY(joy) == y) return;  // Axis hasn't changed
 
@@ -519,6 +521,10 @@ int32_t XInputController::rescaleInput(int32_t val, const Range& in, const Range
 	if (val >= in.max) return out.max;  // Out of range +
 	if (in.min == out.min && in.max == out.max) return val;  // Ranges identical
 	return map(val, in.min, in.max, out.min, out.max);
+}
+
+int16_t XInputController::invertInput(int16_t val, const Range& range) {
+	return range.max - val + range.min;
 }
 
 void XInputController::setTriggerRange(int32_t rangeMin, int32_t rangeMax) {

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -370,9 +370,15 @@ void XInputController::setAutoSend(boolean a) {
 }
 
 boolean XInputController::getButton(uint8_t button) const {
-	const XInputMap_Button * buttonData = getButtonFromEnum((XInputControl) button);
-	if (buttonData == nullptr) return 0;  // Not a button
-	return tx[buttonData->index] & buttonData->mask;
+	const XInputMap_Button* buttonData = getButtonFromEnum((XInputControl) button);
+	if (buttonData != nullptr) {
+		return tx[buttonData->index] & buttonData->mask;
+	}
+	const XInputMap_Trigger* triggerData = getTriggerFromEnum((XInputControl) button);
+	if (triggerData != nullptr) {
+		return getTrigger((XInputControl) button) != 0 ? 1 : 0;
+	}
+	return 0;  // Not a button or a trigger
 }
 
 boolean XInputController::getDpad(XInputControl dpad) const {

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -341,15 +341,18 @@ void XInputController::setJoystickDirect(XInputControl joy, int16_t x, int16_t y
 	const XInputMap_Joystick * joyData = getJoyFromEnum(joy);
 	if (joyData == nullptr) return;  // Not a joystick
 
-	if (getJoystickX(joy) == x && getJoystickY(joy) == y) return;  // Joy hasn't changed
+	if (getJoystickX(joy) != x) {
+		tx[joyData->x_low] = lowByte(x);
+		tx[joyData->x_high] = highByte(x);
+		newData = true;
+	}
 
-	tx[joyData->x_low]  = lowByte(x);
-	tx[joyData->x_high] = highByte(x);
+	if (getJoystickY(joy) != y) {
+		tx[joyData->y_low] = lowByte(y);
+		tx[joyData->y_high] = highByte(y);
+		newData = true;
+	}
 
-	tx[joyData->y_low]  = lowByte(y);
-	tx[joyData->y_high] = highByte(y);
-
-	newData = true;
 	autosend();
 }
 

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -86,14 +86,14 @@ public:
 	void setButton(uint8_t button, boolean state);
 
 	void setDpad(XInputControl pad, boolean state);
-	void setDpad(boolean up, boolean down, boolean left, boolean right, boolean useSOCD = true);
+	void setDpad(boolean up, boolean down, boolean left, boolean right, boolean useSOCD=true);
 
 	void setTrigger(XInputControl trigger, int32_t val);
 
 	void setJoystick(XInputControl joy, int32_t x, int32_t y);
-	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD = true);
 	void setJoystickX(XInputControl joy, int32_t x);
 	void setJoystickY(XInputControl joy, int32_t y);
+	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD=true);
 
 	void releaseAll();
 
@@ -136,7 +136,7 @@ public:
 	void reset();
 
 	// Debug
-	void printDebug(Print& output = Serial) const;
+	void printDebug(Print& output=Serial) const;
 
 private:
 	// Sent Data

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -91,8 +91,8 @@ public:
 	void setTrigger(XInputControl trigger, int32_t val);
 
 	void setJoystick(XInputControl joy, int32_t x, int32_t y);
-	void setJoystickX(XInputControl joy, int32_t x);
-	void setJoystickY(XInputControl joy, int32_t y);
+	void setJoystickX(XInputControl joy, int32_t x, boolean invert=false);
+	void setJoystickY(XInputControl joy, int32_t y, boolean invert=false);
 	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD=true);
 
 	void releaseAll();
@@ -162,6 +162,7 @@ private:
 	Range rangeTrigLeft, rangeTrigRight, rangeJoyLeft, rangeJoyRight;
 	Range * getRangeFromEnum(XInputControl ctrl);
 	static int32_t rescaleInput(int32_t val, const Range& in, const Range &out);
+	static int16_t invertInput(int16_t val, const Range& range);
 };
 
 extern XInputController XInput;

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -161,7 +161,7 @@ private:
 	// Control Input Ranges
 	Range rangeTrigLeft, rangeTrigRight, rangeJoyLeft, rangeJoyRight;
 	Range * getRangeFromEnum(XInputControl ctrl);
-	int32_t rescaleInput(int32_t val, Range in, Range out);
+	static int32_t rescaleInput(int32_t val, const Range& in, const Range &out);
 };
 
 extern XInputController XInput;

--- a/src/XInput.h
+++ b/src/XInput.h
@@ -91,9 +91,9 @@ public:
 	void setTrigger(XInputControl trigger, int32_t val);
 
 	void setJoystick(XInputControl joy, int32_t x, int32_t y);
+	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD=true);
 	void setJoystickX(XInputControl joy, int32_t x, boolean invert=false);
 	void setJoystickY(XInputControl joy, int32_t y, boolean invert=false);
-	void setJoystick(XInputControl joy, boolean up, boolean down, boolean left, boolean right, boolean useSOCD=true);
 
 	void releaseAll();
 


### PR DESCRIPTION
The main change in this PR is the option to invert joysticks. When setting a joystick using the axis-specific function (e.g. `setJoystickY`) the user can pass an optional third boolean argument which inverts the output.

While I was at it I also adjusted the `getButton` function to return a boolean interpretation of the trigger values (`!= 0 ? 1 : 0`). This allows the 'get' function to match the 'set' function in treating the analog triggers as digital. I debated about what to set the threshold at, but eventually settled on "any input" because it covers the most ground. If the user needs a higher threshold they can do it themselves with the output from the analog trigger function.

This PR also includes minor improvements to the internal joystick setting function (`setJoystickDirect`) and the input rescaling function, neither of which should affect the public API.

Lastly the serial version of the `send` function has been modified so that both modes (serial and emulation) toggle the internal `newData` flag. This effectively restricts the `send` debug output to only print values on change, same as the library in emulation mode. This change should make it easier to see atomic changes (e.g. single button presses), debug the `newData` flag itself, and declutters the serial motor generally. If users prefer the old version with the constant status output they can call `printDebug()` wherever necessary.