### PR TITLE
Flush receive buffer on construction

### DIFF
--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -200,6 +200,7 @@ XInputController::XInputController() :
 	reset();
 #ifdef USB_XINPUT
 	XInputUSB::setRecvCallback(XInputLib_Receive_Callback);
+	while(this->receive());  // flush USB OUT buffer
 #endif
 }
 


### PR DESCRIPTION
On certain platforms this was causing a problem where the library was always one or two packets behind because USB packets were received and buffered by the hardware controller before the library object was constructed and could set its callback. Flushing the receive buffer when the object is constructed appears to solve this issue.