### PR TITLE
Add teensy 4 support

### DIFF
--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -38,9 +38,11 @@
 	// Teensy LC:       __MKL26Z64__
 	// Teensy 3.5:      __MK64FX512__
 	// Teensy 3.6:      __MK66FX1M0__
+        // Teensy 4.0-4.1   __IMXRT1062__
 	#if  !defined(__MK20DX256__) && !defined(__MKL26Z64__) && \
-		 !defined(__MK64FX512__) && !defined(__MK66FX1M0__)
-		#warning "Not a supported board! Must use Teensy 3.1/3.2, LC, 3.5, or 3.6"
+		 !defined(__MK64FX512__) && !defined(__MK66FX1M0__) && \
+		 !defined(__IMXRT1062__)
+		#warning "Not a supported board! Must use Teensy 3.1/3.2, LC, 3.5, 3.6, or 4.0/4.1"
 	#elif !defined(USB_XINPUT)
 		#warning "USB type is not set to XInput in boards menu! Using debug print - board will not behave as an XInput device"
 	#endif /* if supported Teensy board */


### PR DESCRIPTION
Only tested on a teensy 4.1, but it should work on the 4.0 as well.

Corresponding board support PR: https://github.com/dmadison/ArduinoXInput_Teensy/pull/26