### PR TITLE
Teensy 4 Boards Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Arduino IDE
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
 
     strategy:
       matrix:
-        board: ['Arduino Leonardo (Serial)', 'Arduino Leonardo (XInput)', 'Teensy LC']
+        board: ['Arduino Leonardo (Serial)', 'Arduino Leonardo (XInput)', 'Teensy 3.2']
         include:
           - board: 'Arduino Leonardo (Serial)'
             fqbn: arduino:avr:leonardo
           - board: 'Arduino Leonardo (XInput)'
             fqbn: xinput:avr:leonardo
-          - board: 'Teensy LC'
-            fqbn: teensy:avr:teensyLC:usb=xinput,speed=48,opt=osstd,keys=en-us
+          - board: 'Teensy 3.2'
+            fqbn: teensy:avr:teensy31:usb=xinput,speed=72,opt=o2std,keys=en-us
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        board: ['Arduino Leonardo (Serial)', 'Arduino Leonardo (XInput)', 'Teensy 3.2']
+        board: ['Arduino Leonardo (Serial)', 'Arduino Leonardo (XInput)', 'Teensy 3.2', 'Teensy 4.0']
         include:
           - board: 'Arduino Leonardo (Serial)'
             fqbn: arduino:avr:leonardo
@@ -21,6 +21,8 @@ jobs:
             fqbn: xinput:avr:leonardo
           - board: 'Teensy 3.2'
             fqbn: teensy:avr:teensy31:usb=xinput,speed=72,opt=o2std,keys=en-us
+          - board: 'Teensy 4.0'
+            fqbn: teensy:avr:teensy40:usb=xinput,speed=600,opt=o2std,keys=en-us
 
     steps:
       - name: Checkout

--- a/extras/SupportedBoards.md
+++ b/extras/SupportedBoards.md
@@ -26,9 +26,12 @@ Here is a complete list of all of the currently supported boards. Each header li
 * [Qduino Mini](https://www.sparkfun.com/products/13614)
 * [LilyPad USB Plus](https://www.sparkfun.com/products/14346)
 
-## [Teensy 3 Boards](https://github.com/dmadison/ArduinoXInput_Teensy/)
+## [Teensy Boards](https://github.com/dmadison/ArduinoXInput_Teensy/)
 
 * [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)
 * [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)
 * [Teensy 3.1](https://www.pjrc.com/store/teensy31.html) / [3.2](https://www.pjrc.com/store/teensy32.html)
-* [Teensy LC](https://www.pjrc.com/teensy/teensyLC.html)
+* [Teensy LC](https://www.pjrc.com/store/teensylc.html)
+* [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)
+* [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)
+* [Teensy MicroMod](https://www.sparkfun.com/products/16402)

--- a/src/XInput.cpp
+++ b/src/XInput.cpp
@@ -32,17 +32,17 @@
 		#warning "Non-XInput version selected in boards menu! Using debug print - board will not behave as an XInput device"
 	#endif
 
-// Teensy 3 Boards
+// Teensy Boards
 #elif defined(TEENSYDUINO)
-	// Teensy 3.1-3.2:  __MK20DX256__
-	// Teensy LC:       __MKL26Z64__
-	// Teensy 3.5:      __MK64FX512__
-	// Teensy 3.6:      __MK66FX1M0__
-        // Teensy 4.0-4.1   __IMXRT1062__
+	// Teensy 3.1-3.2:            __MK20DX256__
+	// Teensy LC:                 __MKL26Z64__
+	// Teensy 3.5:                __MK64FX512__
+	// Teensy 3.6:                __MK66FX1M0__
+	// Teensy 4.0, 4.1, MicroMod  __IMXRT1062__
 	#if  !defined(__MK20DX256__) && !defined(__MKL26Z64__) && \
 		 !defined(__MK64FX512__) && !defined(__MK66FX1M0__) && \
 		 !defined(__IMXRT1062__)
-		#warning "Not a supported board! Must use Teensy 3.1/3.2, LC, 3.5, 3.6, or 4.0/4.1"
+		#warning "Not a supported board! Must use Teensy 3.1/3.2, LC, 3.5, 3.6, 4.0, 4.1, or MicroMod"
 	#elif !defined(USB_XINPUT)
 		#warning "USB type is not set to XInput in boards menu! Using debug print - board will not behave as an XInput device"
 	#endif /* if supported Teensy board */


### PR DESCRIPTION
Adds the Teensy 4 series of boards (Teensy 4.0, Teensy 4.1, Teensy MicroMod) to the CI and list of supported boards.