### PR TITLE
Update CI to Teensyduino 1.57

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   IDE_VERSION: 1.8.19
-  TEENSY_VERSION: 156
+  TEENSY_VERSION: 157
   IDE_LOCATION: /usr/local/share/arduino
 
 jobs:

--- a/.github/workflows/remove_teensyloader.py
+++ b/.github/workflows/remove_teensyloader.py
@@ -12,7 +12,7 @@ with open(filepath, 'r') as f:
 
 with open(filepath, 'w') as f:
 	# matching "postbuild" hooks of any number which call the "teensy_post_compile" application
-	pattern = re.compile("recipe\.hooks\.postbuild\.[0-9]\.pattern=\"{compiler\.path}teensy_post_compile\"")
+	pattern = re.compile("recipe\.hooks\.postbuild\.[0-9]\.pattern=\"{teensytools\.path}teensy_post_compile\"")
 	for line in lines:
 		if not pattern.match(line):
 			f.write(line)


### PR DESCRIPTION
Updates the CI to use Teensyduino 1.57, matching the latest version of [the Teensy core](https://github.com/dmadison/ArduinoXInput_Teensy). Also updates the `remove_teensyloader` helper script regex to match the changed `platform.txt` file.